### PR TITLE
Minimum add for valid parentheses

### DIFF
--- a/src/Challenges/String.cs
+++ b/src/Challenges/String.cs
@@ -797,5 +797,20 @@ namespace LeetCode
 
             return result;
         }
+
+        /// <summary>
+        /// LeetCode Problem 921: https://leetcode.com/problems/minimum-add-to-make-parentheses-valid/
+        /// </summary>
+        public static int MinAddToMakeValid(string S) {
+            int total = 0, unclosedOpen = 0;
+            foreach(char c in S){
+                if (c == '(') unclosedOpen++;
+                else {
+                    if (unclosedOpen > 0) unclosedOpen--;
+                    else  total++;
+                }
+            }
+            return total + unclosedOpen;
+        }
     }
 }

--- a/src/Tests/StringTests.cs
+++ b/src/Tests/StringTests.cs
@@ -273,6 +273,18 @@ namespace LeetCode.Tests
             Assert.True(Enumerable.SequenceEqual(expected,actual));
         }
 
+        [Theory]
+        [InlineData("", 0)]
+        [InlineData("())", 1)]
+        [InlineData("(((", 3)]
+        [InlineData("()", 0)]
+        [InlineData("()))((", 4)]
+        [InlineData("()(((())()()((()(", 5)]
+        public void MinAddToMakeValid(string S, int expected){
+            var actual = String.MinAddToMakeValid(S);
+            Assert.Equal(expected, actual);
+        }
+
         #region Test Data
 
         public static readonly List<object[]> FindAndReplacePatternData


### PR DESCRIPTION
LeetCode problem 921: https://leetcode.com/problems/minimum-add-to-make-parentheses-valid/

Takes a string of parentheses, and returns the number of parentheses that need to be added for it to be a valid string.

Solution + tests.